### PR TITLE
Several fix ups

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,4 +1,4 @@
 Library Usage
 =============
 
-This page will describe the workflow for this library.
+This page will describe the work flow for this library.

--- a/pyiddidf/__init__.py
+++ b/pyiddidf/__init__.py
@@ -1,5 +1,5 @@
 import idd
 import idf
 
-__version__ = 0.5
+__version__ = 0.6
 __all__ = ['idd', 'idf', 'exceptions']

--- a/pyiddidf/__init__.py
+++ b/pyiddidf/__init__.py
@@ -1,1 +1,5 @@
+import idd
+import idf
+
 __version__ = 0.5
+__all__ = ['idd', 'idf', 'exceptions']

--- a/pyiddidf/idf/objects.py
+++ b/pyiddidf/idf/objects.py
@@ -107,6 +107,9 @@ class IDFObject(object):
         else:
             if len(self.fields) == 0:
                 s = self.object_name + ";\n"
+            elif '\\format' in idd_object.meta_data and 'singleLine' in idd_object.meta_data['\\format']:
+                field_token_string = ",".join([field for field in self.fields])
+                s = self.object_name + ',' + field_token_string + ';\n'
             else:
                 idd_fields = idd_object.fields
                 s = self.object_name + ",\n"

--- a/test/idf/test_processor.py
+++ b/test/idf/test_processor.py
@@ -149,7 +149,14 @@ class TestIDFProcessingViaFile(unittest.TestCase):
         idd_path = os.path.join(self.support_file_dir, "Energy+.idd")
         idd_processor = IDDProcessor()
         idd_structure = idd_processor.process_file_given_file_path(idd_path)
-        out_idf_file_path = tempfile.mktemp()
+        out_idf_file_path = tempfile.mktemp(suffix=".idf")
+        # print("Writing new idf to: " + out_idf_file_path)
         idf_structure.write_idf(out_idf_file_path, idd_structure)
         # soon we'd like to assert that the original and the newly written are the same
-        # this can't be done right now primarily due to the library not abiding by the singleline idd attribute
+        # this can't be done right now primarily because the original idf is not "properly" formatted
+        # the 3 points of vertices on surfaces are on one line which I'm not planning to support
+        # similar with the schedule:compact objects
+        # I just need to pick a better idf file to start with
+
+        # import filecmp
+        # filecmp.cmp(idf_path, out_idf_file_path)

--- a/test/idf/test_processor.py
+++ b/test/idf/test_processor.py
@@ -1,9 +1,11 @@
 import StringIO
 import os
+import tempfile
 import unittest
 
 from pyiddidf.exceptions import ProcessingException
 from pyiddidf.idf.processor import IDFProcessor
+from pyiddidf.idd.processor import IDDProcessor
 
 
 class TestIDFProcessingViaStream(unittest.TestCase):
@@ -138,3 +140,16 @@ class TestIDFProcessingViaFile(unittest.TestCase):
         idf_structure = processor.process_file_given_file_path(idf_path)
         self.assertEquals(1, len(idf_structure.objects))
         self.assertAlmostEqual(idf_structure.version_float, 1.1, 1)
+
+    def test_rewriting_idf(self):
+        idf_path = os.path.join(self.support_file_dir, "1ZoneEvapCooler.idf")
+        idf_processor = IDFProcessor()
+        idf_structure = idf_processor.process_file_given_file_path(idf_path)
+        self.assertEquals(80, len(idf_structure.objects))
+        idd_path = os.path.join(self.support_file_dir, "Energy+.idd")
+        idd_processor = IDDProcessor()
+        idd_structure = idd_processor.process_file_given_file_path(idd_path)
+        out_idf_file_path = tempfile.mktemp()
+        idf_structure.write_idf(out_idf_file_path, idd_structure)
+        # soon we'd like to assert that the original and the newly written are the same
+        # this can't be done right now primarily due to the library not abiding by the singleline idd attribute


### PR DESCRIPTION
Most prominent I'd say is the support for the `\format singleLine` IDD declaration.  Now IDF objects of these types will be written out in the expected single line, making it more possible to do a 'read-idd, read-idf, write-same-idf' process and have the original and final idfs the same.